### PR TITLE
Database improvements

### DIFF
--- a/src/ST-DB/DB.cs
+++ b/src/ST-DB/DB.cs
@@ -1,24 +1,26 @@
 namespace SurfTimer;
 
+using System;
 using System.Runtime.CompilerServices;
 using CounterStrikeSharp.API;
 using MySqlConnector; // https://dev.mysql.com/doc/connector-net/en/connector-net-connections-string.html
 
 // This will have functions for DB access and query sending
-internal class TimerDatabase 
+internal class TimerDatabase
 {
     private MySqlConnection? _db;
-    private string _connString;
+    private readonly string _connString = string.Empty;
 
     public TimerDatabase()
     {
         // Null'd
     }
 
+
     public TimerDatabase(string host, string database, string user, string password, int port, int timeout)
     {
         this._connString = $"server={host};user={user};password={password};database={database};port={port};connect timeout={timeout};";
-        this._db = new MySqlConnection(this._connString);
+        this._db = new MySqlConnection(_connString);
         this._db.Open();
     }
 
@@ -30,17 +32,49 @@ internal class TimerDatabase
 
     public async Task<MySqlDataReader> Query(string query)
     {
-        MySqlCommand cmd = new MySqlCommand(query, this._db);
-        MySqlDataReader reader = await cmd.ExecuteReaderAsync();
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                if (this._db == null)
+                {
+                    throw new InvalidOperationException("Database connection is not open.");
+                }
 
-        return Task.FromResult(reader).Result;
+                MySqlCommand cmd = new(query, this._db);
+                MySqlDataReader reader = await cmd.ExecuteReaderAsync();
+
+                return reader;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error executing query: {ex.Message}");
+                throw;
+            }
+        });
     }
 
     public async Task<int> Write(string query)
     {
-        MySqlCommand cmd = new MySqlCommand(query, this._db);
-        int rowsAffected = await cmd.ExecuteNonQueryAsync();
+        return await Task.Run(async () =>
+        {
+            try
+            {
+                if (this._db == null)
+                {
+                    throw new InvalidOperationException("Database connection is not open.");
+                }
 
-        return rowsAffected;
+                MySqlCommand cmd = new(query, this._db);
+                int rowsAffected = await cmd.ExecuteNonQueryAsync();
+
+                return rowsAffected;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error executing write operation: {ex.Message}");
+                throw;
+            }
+        });
     }
 }

--- a/src/ST-DB/DB.cs
+++ b/src/ST-DB/DB.cs
@@ -20,7 +20,7 @@ internal class TimerDatabase
     public TimerDatabase(string host, string database, string user, string password, int port, int timeout)
     {
         this._connString = $"server={host};user={user};password={password};database={database};port={port};connect timeout={timeout};";
-        this._db = new MySqlConnection(_connString);
+        this._db = new MySqlConnection(this._connString);
         this._db.Open();
     }
 


### PR DESCRIPTION
Since the Query and Write methods are asynchronous, using `await Task.Run(() => ...)` to offload CPU-bound work to a background thread to avoid deadlocks in certain scenarios.

error handling, incorrect queries, db connection drops, timeouts

_connString readonly as its value is set only in the constructor and doesn't change throughout the lifetime of the object.