### PR TITLE
Bonus timing + some other things

### DIFF
--- a/cfg/SurfTimer/server_settings.cfg
+++ b/cfg/SurfTimer/server_settings.cfg
@@ -76,5 +76,6 @@ mp_warmup_end
 mp_warmuptime 0
 sv_holiday_mode 0
 sv_party_mode 0
+sv_hibernate_when_empty 0
 
 sv_cheats 0

--- a/src/ST-Commands/PlayerCommands.cs
+++ b/src/ST-Commands/PlayerCommands.cs
@@ -40,6 +40,7 @@ public partial class SurfTimer
     }
 
     [ConsoleCommand("css_s", "Teleport to a stage")]
+    [ConsoleCommand("css_stage", "Teleport to a stage")]
     [CommandHelper(whoCanExecute: CommandUsage.CLIENT_ONLY)]
     public void PlayerGoToStage(CCSPlayerController? player, CommandInfo command)
     {

--- a/src/ST-Commands/PlayerCommands.cs
+++ b/src/ST-Commands/PlayerCommands.cs
@@ -122,7 +122,7 @@ public partial class SurfTimer
             return;
         }
 
-        int bonus = Int32.Parse(command.ArgByIndex(1)) - 1;
+        int bonus = Int32.Parse(command.ArgByIndex(1));
 
         if (CurrentMap.Bonuses <= 0)
         {

--- a/src/ST-Commands/PlayerCommands.cs
+++ b/src/ST-Commands/PlayerCommands.cs
@@ -60,10 +60,10 @@ public partial class SurfTimer
         if (player == null)
             return;
 
-        int stage = Int32.Parse(command.ArgByIndex(1)) - 1;
+        int stage = Int32.Parse(command.ArgByIndex(1));
 
         // Must be 1 argument
-        if (command.ArgCount < 2 || stage < 0)
+        if (command.ArgCount < 2 || stage <= 0)
         {
             #if DEBUG
             player.PrintToChat($"CS2 Surf DEBUG >> css_stage >> Arg#: {command.ArgCount} >> Args: {Int32.Parse(command.ArgByIndex(1))}");
@@ -87,7 +87,7 @@ public partial class SurfTimer
 
         if (CurrentMap.StageStartZone[stage] != new Vector(0, 0, 0))
         {
-            if (stage == 0)
+            if (stage == 1)
                 Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StartZone, CurrentMap.StartZoneAngles, new Vector(0, 0, 0)));
             else
                 Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StageStartZone[stage], CurrentMap.StageStartZoneAngles[stage], new Vector(0, 0, 0)));

--- a/src/ST-Commands/PlayerCommands.cs
+++ b/src/ST-Commands/PlayerCommands.cs
@@ -48,22 +48,27 @@ public partial class SurfTimer
             return;
 
         int stage = Int32.Parse(command.ArgByIndex(1)) - 1;
-        if (stage > CurrentMap.Stages - 1 && CurrentMap.Stages > 0)
-            stage = CurrentMap.Stages - 1;
 
         // Must be 1 argument
         if (command.ArgCount < 2 || stage < 0)
         {
             #if DEBUG
-            player.PrintToChat($"CS2 Surf DEBUG >> css_s >> Arg#: {command.ArgCount} >> Args: {Int32.Parse(command.ArgByIndex(1))}");
+            player.PrintToChat($"CS2 Surf DEBUG >> css_stage >> Arg#: {command.ArgCount} >> Args: {Int32.Parse(command.ArgByIndex(1))}");
             #endif
 
             player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid arguments. Usage: {ChatColors.Green}!s <stage>");
             return;
         }
+
         else if (CurrentMap.Stages <= 0)
         {
             player.PrintToChat($"{PluginPrefix} {ChatColors.Red}This map has no stages.");
+            return;
+        }
+
+        else if (stage > CurrentMap.Stages)
+        {
+            player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid stage provided, this map has {ChatColors.Green}{CurrentMap.Stages} stages.");
             return;
         }
 
@@ -83,6 +88,51 @@ public partial class SurfTimer
 
         else
             player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid stage provided. Usage: {ChatColors.Green}!s <stage>");
+    }
+
+    [ConsoleCommand("css_b", "Teleport to a bonus")]
+    [ConsoleCommand("css_bonus", "Teleport to a bonus")]
+    [CommandHelper(whoCanExecute: CommandUsage.CLIENT_ONLY)]
+    public void PlayerGoToBonus(CCSPlayerController? player, CommandInfo command)
+    {
+        if (player == null)
+            return;
+
+        int bonus = Int32.Parse(command.ArgByIndex(1)) - 1;
+
+        // Must be 1 argument
+        if (command.ArgCount < 2 || bonus < 0)
+        {
+            #if DEBUG
+            player.PrintToChat($"CS2 Surf DEBUG >> css_bonus >> Arg#: {command.ArgCount} >> Args: {Int32.Parse(command.ArgByIndex(1))}");
+            #endif
+
+            player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid arguments. Usage: {ChatColors.Green}!bonus <bonus>");
+            return;
+        }
+
+        else if (CurrentMap.Bonuses <= 0)
+        {
+            player.PrintToChat($"{PluginPrefix} {ChatColors.Red}This map has no bonuses.");
+            return;
+        }
+
+        else if (bonus > CurrentMap.Bonuses)
+        {
+            player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid bonus provided, this map has {ChatColors.Green}{CurrentMap.Bonuses} bonuses.");
+            return;
+        }
+
+        if (CurrentMap.BonusStartZone[bonus] != new Vector(0, 0, 0))
+        {
+            Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.BonusStartZone[bonus], CurrentMap.BonusStartZoneAngles[bonus], new Vector(0, 0, 0)));
+
+            playerList[player.UserId ?? 0].Timer.Reset();
+            playerList[player.UserId ?? 0].Timer.IsBonusMode = true;
+        }
+
+        else
+            player.PrintToChat($"{PluginPrefix} {ChatColors.Red}Invalid bonus provided. Usage: {ChatColors.Green}!bonus <bonus>");
     }
 
     [ConsoleCommand("css_spec", "Moves a player automaticlly into spectator mode")]

--- a/src/ST-Commands/PlayerCommands.cs
+++ b/src/ST-Commands/PlayerCommands.cs
@@ -32,10 +32,23 @@ public partial class SurfTimer
 
         // To-do: players[userid].Timer.Reset() -> teleport player
         Player SurfPlayer = playerList[player.UserId ?? 0];
-        if (SurfPlayer.Timer.Stage != 0 && CurrentMap.StageStartZone[SurfPlayer.Timer.Stage] != new Vector(0, 0, 0))
-            Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StageStartZone[SurfPlayer.Timer.Stage], CurrentMap.StageStartZoneAngles[SurfPlayer.Timer.Stage], new Vector(0, 0, 0)));
-        else // Reset back to map start
-            Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StartZone, new QAngle(0, 0, 0), new Vector(0, 0, 0)));
+
+        if (SurfPlayer.Timer.IsBonusMode)
+        {
+            if (SurfPlayer.Timer.Bonus != 0 && CurrentMap.BonusStartZone[SurfPlayer.Timer.Bonus] != new Vector(0, 0, 0))
+                Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.BonusStartZone[SurfPlayer.Timer.Bonus], CurrentMap.BonusStartZoneAngles[SurfPlayer.Timer.Bonus], new Vector(0, 0, 0)));
+            else // Reset back to map start
+                Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StartZone, new QAngle(0, 0, 0), new Vector(0, 0, 0)));
+        }
+
+        else
+        {
+            if (SurfPlayer.Timer.Stage != 0 && CurrentMap.StageStartZone[SurfPlayer.Timer.Stage] != new Vector(0, 0, 0))
+                Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StageStartZone[SurfPlayer.Timer.Stage], CurrentMap.StageStartZoneAngles[SurfPlayer.Timer.Stage], new Vector(0, 0, 0)));
+            else // Reset back to map start
+                Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.StartZone, new QAngle(0, 0, 0), new Vector(0, 0, 0)));
+        }
+        
         return;
     }
 
@@ -98,10 +111,8 @@ public partial class SurfTimer
         if (player == null)
             return;
 
-        int bonus = Int32.Parse(command.ArgByIndex(1)) - 1;
-
         // Must be 1 argument
-        if (command.ArgCount < 2 || bonus < 0)
+        if (command.ArgCount < 2)
         {
             #if DEBUG
             player.PrintToChat($"CS2 Surf DEBUG >> css_bonus >> Arg#: {command.ArgCount} >> Args: {Int32.Parse(command.ArgByIndex(1))}");
@@ -111,7 +122,9 @@ public partial class SurfTimer
             return;
         }
 
-        else if (CurrentMap.Bonuses <= 0)
+        int bonus = Int32.Parse(command.ArgByIndex(1)) - 1;
+
+        if (CurrentMap.Bonuses <= 0)
         {
             player.PrintToChat($"{PluginPrefix} {ChatColors.Red}This map has no bonuses.");
             return;
@@ -125,10 +138,10 @@ public partial class SurfTimer
 
         if (CurrentMap.BonusStartZone[bonus] != new Vector(0, 0, 0))
         {
-            Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.BonusStartZone[bonus], CurrentMap.BonusStartZoneAngles[bonus], new Vector(0, 0, 0)));
-
             playerList[player.UserId ?? 0].Timer.Reset();
             playerList[player.UserId ?? 0].Timer.IsBonusMode = true;
+
+            Server.NextFrame(() => player.PlayerPawn.Value!.Teleport(CurrentMap.BonusStartZone[bonus], CurrentMap.BonusStartZoneAngles[bonus], new Vector(0, 0, 0)));
         }
 
         else

--- a/src/ST-Events/TriggerEndTouch.cs
+++ b/src/ST-Events/TriggerEndTouch.cs
@@ -50,7 +50,7 @@ public partial class SurfTimer
                     }
 
                     // MAP START ZONE
-                    if (!player.Timer.IsStageMode)
+                    if (!player.Timer.IsStageMode && !player.Timer.IsBonusMode)
                     {
                         player.Timer.Start();
                         player.ReplayRecorder.CurrentSituation = ReplayFrameSituation.START_RUN;

--- a/src/ST-Events/TriggerEndTouch.cs
+++ b/src/ST-Events/TriggerEndTouch.cs
@@ -152,6 +152,27 @@ public partial class SurfTimer
                         // Handle the case where the index is out of bounds
                     }
                 }
+            
+                // Bonus start zones -- hook into (b)onus#_start
+                else if (Regex.Match(trigger.Entity.Name, "^b([1-9][0-9]?|onus[1-9][0-9]?)_start$").Success)
+                {
+                    #if DEBUG
+                    player.Controller.PrintToChat($"CS2 Surf DEBUG >> CBaseTrigger_{ChatColors.LightRed}EndTouchFunc{ChatColors.Default} -> {ChatColors.Yellow}Bonus {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} Start Zone");
+                    #endif
+
+                    // BONUS START ZONE
+                    if (!player.Timer.IsStageMode && player.Timer.IsBonusMode)
+                    {
+                        player.Timer.Start();
+                        // To-do: bonus replay
+                    }
+
+                    // Prespeed display
+                    player.Controller.PrintToCenter($"Prespeed: {velocity.ToString("0")} u/s");
+                    player.Stats.ThisRun.StartVelX = velocity_x; // Start pre speed for the run
+                    player.Stats.ThisRun.StartVelY = velocity_y; // Start pre speed for the run
+                    player.Stats.ThisRun.StartVelZ = velocity_z; // Start pre speed for the run
+                }
             }
 
             return HookResult.Continue;

--- a/src/ST-Events/TriggerEndTouch.cs
+++ b/src/ST-Events/TriggerEndTouch.cs
@@ -103,7 +103,7 @@ public partial class SurfTimer
                         currentCheckpoint.EndVelX = velocity_x;
                         currentCheckpoint.EndVelY = velocity_y;
                         currentCheckpoint.EndVelZ = velocity_z;
-                        currentCheckpoint.EndTouch = player.Timer.Ticks; // To-do: what type of value we store in DB ?
+                        currentCheckpoint.EndTouch = player.Timer.Ticks;
                         currentCheckpoint.Attempts += 1;
                         // Assign the updated currentCheckpoint back to the list as `currentCheckpoint` is supposedly a copy of the original object
                         player.Stats.ThisRun.Checkpoint[player.Timer.Checkpoint] = currentCheckpoint;
@@ -139,7 +139,7 @@ public partial class SurfTimer
                         currentCheckpoint.EndVelX = velocity_x;
                         currentCheckpoint.EndVelY = velocity_y;
                         currentCheckpoint.EndVelZ = velocity_z;
-                        currentCheckpoint.EndTouch = player.Timer.Ticks; // To-do: what type of value we store in DB ?
+                        currentCheckpoint.EndTouch = player.Timer.Ticks;
                         currentCheckpoint.Attempts += 1;
                         // Assign the updated currentCheckpoint back to the list as `currentCheckpoint` is supposedly a copy of the original object
                         player.Stats.ThisRun.Checkpoint[player.Timer.Checkpoint] = currentCheckpoint;

--- a/src/ST-Events/TriggerStartTouch.cs
+++ b/src/ST-Events/TriggerStartTouch.cs
@@ -220,6 +220,24 @@ public partial class SurfTimer
                     player.Controller.PrintToChat($"CS2 Surf DEBUG >> CBaseTrigger_{ChatColors.Lime}StartTouchFunc{ChatColors.Default} -> {ChatColors.LightBlue}Checkpoint {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} Zone");
                     #endif
                 }
+            
+                // Bonus start zones -- hook into bonus_start
+                else if (trigger.Entity.Name.Contains("bonus_start"))
+                {
+                    // We only want this working if they're in bonus mode, ignore otherwise.
+                    if (player.Timer.IsBonusMode) 
+                    {
+                        int bonus = Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1;
+                        player.Timer.Bonus = bonus;
+
+                        player.Controller.PrintToCenter($"Bonus Start ({trigger.Entity.Name})");
+
+                        #if DEBUG
+                        Console.WriteLine($"CS2 Surf DEBUG >> CBaseTrigger_StartTouchFunc (Bonus start zones) -> player.Timer.IsRunning: {player.Timer.IsRunning}");
+                        Console.WriteLine($"CS2 Surf DEBUG >> CBaseTrigger_StartTouchFunc (Bonus start zones) -> !player.Timer.IsBonusMode: {!player.Timer.IsBonusMode}");
+                        #endif
+                    }
+                }
             }
 
             return HookResult.Continue;

--- a/src/ST-Events/TriggerStartTouch.cs
+++ b/src/ST-Events/TriggerStartTouch.cs
@@ -221,13 +221,15 @@ public partial class SurfTimer
                     #endif
                 }
             
-                // Bonus start zones -- hook into bonus_start
-                else if (trigger.Entity.Name.Contains("bonus_start"))
+                // Bonus start zones -- hook into (b)onus#_start
+                else if (Regex.Match(trigger.Entity.Name, "^b([1-9][0-9]?|onus[1-9][0-9]?)_start$").Success)
                 {
                     // We only want this working if they're in bonus mode, ignore otherwise.
                     if (player.Timer.IsBonusMode) 
                     {
-                        int bonus = Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1;
+                        player.Timer.Reset();
+                        player.Timer.IsBonusMode = true;
+                        int bonus = Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value);
                         player.Timer.Bonus = bonus;
 
                         player.Controller.PrintToCenter($"Bonus Start ({trigger.Entity.Name})");

--- a/src/ST-Events/TriggerStartTouch.cs
+++ b/src/ST-Events/TriggerStartTouch.cs
@@ -144,7 +144,7 @@ public partial class SurfTimer
                 // Stage start zones -- hook into (s)tage#_start
                 else if (Regex.Match(trigger.Entity.Name, "^s([1-9][0-9]?|tage[1-9][0-9]?)_start$").Success)
                 {
-                    int stage = Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1;
+                    int stage = Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value);
                     player.Timer.Stage = stage;
 
                     #if DEBUG
@@ -156,10 +156,10 @@ public partial class SurfTimer
                     // This should patch up re-triggering *player.Stats.ThisRun.Checkpoint.Count < stage*
                     if (player.Timer.IsRunning && !player.Timer.IsStageMode && player.Stats.ThisRun.Checkpoint.Count < stage)
                     {
-                        player.Timer.Checkpoint = stage; // Stage = Checkpoint when in a run on a Staged map
+                        player.Timer.Checkpoint = stage - 1; // Stage = Checkpoint when in a run on a Staged map
 
                         #if DEBUG
-                        Console.WriteLine($"============== Initial entity value: {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} | Assigned to `stage`: {Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1}");
+                        Console.WriteLine($"============== Initial entity value: {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} | Assigned to `stage`: {Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value)}");
                         Console.WriteLine($"CS2 Surf DEBUG >> CBaseTrigger_StartTouchFunc (Stage start zones) -> player.Stats.PB[{style}].Checkpoint.Count = {player.Stats.PB[style].Checkpoint.Count}");
                         #endif
 
@@ -167,7 +167,7 @@ public partial class SurfTimer
                         player.HUD.DisplayCheckpointMessages(PluginPrefix);
 
                         // store the checkpoint in the player's current run checkpoints used for Checkpoint functionality
-                        Checkpoint cp2 = new Checkpoint(stage,
+                        Checkpoint cp2 = new Checkpoint(player.Timer.Checkpoint,
                                                         player.Timer.Ticks,
                                                         velocity_x,
                                                         velocity_y,
@@ -177,7 +177,7 @@ public partial class SurfTimer
                                                         -1.0f,
                                                         -1.0f,
                                                         0);
-                        player.Stats.ThisRun.Checkpoint[stage] = cp2;
+                        player.Stats.ThisRun.Checkpoint[player.Timer.Checkpoint] = cp2;
                     }
 
                     #if DEBUG
@@ -195,7 +195,7 @@ public partial class SurfTimer
                     if (player.Timer.IsRunning && !player.Timer.IsStageMode && player.Stats.ThisRun.Checkpoint.Count < checkpoint)
                     {
                         #if DEBUG
-                        Console.WriteLine($"============== Initial entity value: {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} | Assigned to `checkpoint`: {Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1}");
+                        Console.WriteLine($"============== Initial entity value: {Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value} | Assigned to `checkpoint`: {Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value)}");
                         Console.WriteLine($"CS2 Surf DEBUG >> CBaseTrigger_StartTouchFunc (Checkpoint zones) -> player.Stats.PB[{style}].Checkpoint.Count = {player.Stats.PB[style].Checkpoint.Count}");
                         #endif
                         

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -299,7 +299,7 @@ internal class Map
             {
                 #if DEBUG
                 Console.WriteLine($"cp {cpWrData.GetInt32("cp")} ");
-                Console.WriteLine($"run_time {cpWrData.GetFloat("run_time")} ");
+                Console.WriteLine($"run_time {cpWrData.GetInt32("run_time")} ");
                 Console.WriteLine($"sVelX {cpWrData.GetFloat("start_vel_x")} ");
                 Console.WriteLine($"sVelY {cpWrData.GetFloat("start_vel_y")} ");
                 #endif

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -98,8 +98,8 @@ internal class Map
                         if (teleport.Entity!.Name != null && 
                             (IsInZone(trigger.AbsOrigin!, trigger.Collision.BoundingRadius, teleport.AbsOrigin!) || (Regex.Match(teleport.Entity.Name, "^spawn_s([1-9][0-9]?|tage[1-9][0-9]?)_start$").Success && Int32.Parse(Regex.Match(teleport.Entity.Name, "[0-9][0-9]?").Value) == stage)))
                         {
-                            this.StageStartZone[stage - 1] = new Vector(teleport.AbsOrigin!.X, teleport.AbsOrigin!.Y, teleport.AbsOrigin!.Z);
-                            this.StageStartZoneAngles[stage - 1] = new QAngle(teleport.AbsRotation!.X, teleport.AbsRotation!.Y, teleport.AbsRotation!.Z);
+                            this.StageStartZone[stage] = new Vector(teleport.AbsOrigin!.X, teleport.AbsOrigin!.Y, teleport.AbsOrigin!.Z);
+                            this.StageStartZoneAngles[stage] = new QAngle(teleport.AbsRotation!.X, teleport.AbsRotation!.Y, teleport.AbsRotation!.Z);
                             this.Stages++; // Count stage zones for the map to populate DB
                             foundPlayerSpawn = true;
                             break;
@@ -108,14 +108,14 @@ internal class Map
 
                     if (!foundPlayerSpawn)
                     {
-                        this.StageStartZone[stage - 1] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                        this.StageStartZone[stage] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
                     }
                 }
 
                 // Checkpoint start zones (linear maps)
                 else if (Regex.Match(trigger.Entity.Name, "^map_c(p[1-9][0-9]?|heckpoint[1-9][0-9]?)$").Success) 
                 {
-                    this.CheckpointStartZone[Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                    this.CheckpointStartZone[Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value)] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
                     this.Checkpoints++; // Might be useful to have this in DB entry
                 }
                 
@@ -151,6 +151,7 @@ internal class Map
                 }
             }
         }
+
         if (this.Stages > 0) this.Stages++; // You did not count the stages right :(
         Console.WriteLine($"[CS2 Surf] Identifying start zone: {this.StartZone.X},{this.StartZone.Y},{this.StartZone.Z}\nIdentifying end zone: {this.EndZone.X},{this.EndZone.Y},{this.EndZone.Z}");
 

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -109,6 +109,7 @@ internal class Map
                     if (!foundPlayerSpawn)
                     {
                         this.StageStartZone[stage] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                        this.Stages++;
                     }
                 }
 
@@ -131,8 +132,8 @@ internal class Map
                         if (teleport.Entity!.Name != null && 
                             (IsInZone(trigger.AbsOrigin!, trigger.Collision.BoundingRadius, teleport.AbsOrigin!) || (Regex.Match(teleport.Entity.Name, "^spawn_b([1-9][0-9]?|onus[1-9][0-9]?)_start$").Success && Int32.Parse(Regex.Match(teleport.Entity.Name, "[0-9][0-9]?").Value) == bonus)))
                         {
-                            this.BonusStartZone[bonus - 1] = new Vector(teleport.AbsOrigin!.X, teleport.AbsOrigin!.Y, teleport.AbsOrigin!.Z);
-                            this.BonusStartZoneAngles[bonus - 1] = new QAngle(teleport.AbsRotation!.X, teleport.AbsRotation!.Y, teleport.AbsRotation!.Z);
+                            this.BonusStartZone[bonus] = new Vector(teleport.AbsOrigin!.X, teleport.AbsOrigin!.Y, teleport.AbsOrigin!.Z);
+                            this.BonusStartZoneAngles[bonus] = new QAngle(teleport.AbsRotation!.X, teleport.AbsRotation!.Y, teleport.AbsRotation!.Z);
                             this.Bonuses++; // Count bonus zones for the map to populate DB
                             foundPlayerSpawn = true;
                             break;
@@ -141,13 +142,14 @@ internal class Map
 
                     if (!foundPlayerSpawn)
                     {
-                        this.BonusStartZone[bonus - 1] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                        this.BonusStartZone[bonus] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                        this.Bonuses++;
                     }
                 }
 
                 else if (Regex.Match(trigger.Entity.Name, "^b([1-9][0-9]?|onus[1-9][0-9]?)_end$").Success) 
                 {
-                    this.BonusEndZone[Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value) - 1] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
+                    this.BonusEndZone[Int32.Parse(Regex.Match(trigger.Entity.Name, "[0-9][0-9]?").Value)] = new Vector(trigger.AbsOrigin!.X, trigger.AbsOrigin!.Y, trigger.AbsOrigin!.Z);
                 }
             }
         }
@@ -192,8 +194,6 @@ internal class Map
                 this.ID = postWriteMapData.GetInt32("id");
                 this.Author = postWriteMapData.GetString("author");
                 this.Tier = postWriteMapData.GetInt32("tier");
-                // this.Stages = -1;    // this should now be populated accordingly when looping through hookzones for the map
-                // this.Bonuses = -1;   // this should now be populated accordingly when looping through hookzones for the map
                 this.Ranked = postWriteMapData.GetBoolean("ranked");
                 this.DateAdded = postWriteMapData.GetInt32("date_added");
                 this.LastPlayed = this.DateAdded; 

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -152,7 +152,8 @@ internal class Map
             }
         }
 
-        if (this.Stages > 0) this.Stages++; // You did not count the stages right :(
+        if (this.Stages > 0) // Account for stage 1, not counted above
+            this.Stages += 1; 
         Console.WriteLine($"[CS2 Surf] Identifying start zone: {this.StartZone.X},{this.StartZone.Y},{this.StartZone.Z}\nIdentifying end zone: {this.EndZone.X},{this.EndZone.Y},{this.EndZone.Z}");
 
         // Gather map information OR create entry

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -40,6 +40,9 @@ internal class Map
     public Vector[] CheckpointStartZone {get;} = Enumerable.Repeat(0, 99).Select(x => new Vector(0,0,0)).ToArray();
 
     // Constructor
+    // To-do: This loops through all the triggers. While that's great and comprehensive, some maps have two triggers with the exact same name, because there are two
+    //        for each side of the course (left and right, for example). We should probably work on automatically catching this. 
+    //        Maybe even introduce a new naming convention?
     internal Map(string Name, TimerDatabase DB)
     {
         // Set map name

--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -305,7 +305,7 @@ internal class Map
                 #endif
 
                 Checkpoint cp = new(cpWrData.GetInt32("cp"),
-                                    cpWrData.GetInt32("run_time"),   // To-do: what type of value we use here? DB uses DECIMAL but `.Tick` is int???
+                                    cpWrData.GetInt32("run_time"),
                                     cpWrData.GetFloat("start_vel_x"),
                                     cpWrData.GetFloat("start_vel_y"),
                                     cpWrData.GetFloat("start_vel_z"),

--- a/src/ST-Player/PlayerHUD.cs
+++ b/src/ST-Player/PlayerHUD.cs
@@ -75,7 +75,14 @@ internal class PlayerHUD
                 else
                     timerColor = "#2E9F65";
             }
-            string timerModule = FormatHUDElementHTML("", FormatTime(_player.Timer.Ticks), timerColor);
+
+            string timerModule;
+            if (_player.Timer.IsBonusMode)
+                timerModule = FormatHUDElementHTML("", $"[B{_player.Timer.Bonus}] "+FormatTime(_player.Timer.Ticks), timerColor);
+            else if (_player.Timer.IsStageMode)
+                timerModule = FormatHUDElementHTML("", $"[S{_player.Timer.Stage}] "+FormatTime(_player.Timer.Ticks), timerColor);
+            else
+                timerModule = FormatHUDElementHTML("", FormatTime(_player.Timer.Ticks), timerColor);
 
             // Velocity Module - To-do: Make velocity module configurable (XY or XYZ velocity)
             float velocity = (float)Math.Sqrt(_player.Controller.PlayerPawn.Value!.AbsVelocity.X * _player.Controller.PlayerPawn.Value!.AbsVelocity.X

--- a/src/ST-Player/PlayerHUD.cs
+++ b/src/ST-Player/PlayerHUD.cs
@@ -44,8 +44,8 @@ internal class PlayerHUD
         {
             case PlayerTimer.TimeFormatStyle.Compact:
                 return time.TotalMinutes < 1
-                    ? $"{time.Seconds:D1}.{millis:D3}"
-                    : $"{time.Minutes:D1}:{time.Seconds:D1}.{millis:D3}";
+                    ? $"{time.Seconds:D2}.{millis:D3}"
+                    : $"{time.Minutes:D1}:{time.Seconds:D2}.{millis:D3}";
             case PlayerTimer.TimeFormatStyle.Full:
                 return $"{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}.{millis:D3}";
             case PlayerTimer.TimeFormatStyle.Verbose:

--- a/src/ST-Player/PlayerHUD.cs
+++ b/src/ST-Player/PlayerHUD.cs
@@ -47,7 +47,9 @@ internal class PlayerHUD
                     ? $"{time.Seconds:D2}.{millis:D3}"
                     : $"{time.Minutes:D1}:{time.Seconds:D2}.{millis:D3}";
             case PlayerTimer.TimeFormatStyle.Full:
-                return $"{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}.{millis:D3}";
+                return time.TotalHours < 1 
+                    ? $"{time.Minutes:D2}:{time.Seconds:D2}.{millis:D3}"
+                    : $"{time.Hours:D2}:{time.Minutes:D2}:{time.Seconds:D2}.{millis:D3}";
             case PlayerTimer.TimeFormatStyle.Verbose:
                 return $"{time.Hours}h {time.Minutes}m {time.Seconds}s {millis}ms";
             default:

--- a/src/ST-Player/PlayerStats/PersonalBest.cs
+++ b/src/ST-Player/PlayerStats/PersonalBest.cs
@@ -22,7 +22,7 @@ internal class PersonalBest
     // Constructor
     public PersonalBest()
     {
-        Ticks = -1; // To-do: what type of value we use here? DB uses DECIMAL but `.Tick` is int???
+        Ticks = -1;
         Checkpoint = new Dictionary<int, Checkpoint>();
         // Type = type;
         StartVelX = -1.0f;

--- a/src/ST-Player/PlayerStats/PlayerStats.cs
+++ b/src/ST-Player/PlayerStats/PlayerStats.cs
@@ -123,7 +123,7 @@ internal class PlayerStats
             #endif
 
             Checkpoint cp = new(results.GetInt32("cp"),
-                                results.GetInt32("run_time"),   // To-do: what type of value we use here? DB uses DECIMAL but `.Tick` is int???
+                                results.GetInt32("run_time"), 
                                 results.GetFloat("start_vel_x"),
                                 results.GetFloat("start_vel_y"),
                                 results.GetFloat("start_vel_z"),

--- a/src/ST-Player/PlayerStats/PlayerStats.cs
+++ b/src/ST-Player/PlayerStats/PlayerStats.cs
@@ -117,7 +117,7 @@ internal class PlayerStats
         {
             #if DEBUG
             Console.WriteLine($"cp {results.GetInt32("cp")} ");
-            Console.WriteLine($"run_time {results.GetFloat("run_time")} ");
+            Console.WriteLine($"run_time {results.GetInt32("run_time")} ");
             Console.WriteLine($"sVelX {results.GetFloat("start_vel_x")} ");
             Console.WriteLine($"sVelY {results.GetFloat("start_vel_y")} ");
             #endif

--- a/src/ST-Player/PlayerTimer.cs
+++ b/src/ST-Player/PlayerTimer.cs
@@ -10,6 +10,7 @@ internal class PlayerTimer
     // Modes
     public bool IsPracticeMode { get; set; } = false; // Practice mode toggle
     public bool IsStageMode { get; set; } = false; // Stage mode toggle
+    public bool IsBonusMode { get; set; } = false; // Bonus mode toggle
 
     // Tracking
     public int Stage { get; set; } = 0; // Current stage tracker
@@ -21,7 +22,7 @@ internal class PlayerTimer
     // Timing
     public int Ticks { get; set; } = 0; // To-do: sub-tick counting? This currently goes on OnTick, which is not sub-tick I believe? Needs investigating
 
-    // Time Formatting
+    // Time Formatting - To-do: Move to player settings maybe?
     public enum TimeFormatStyle
     {
         Compact,
@@ -39,6 +40,7 @@ internal class PlayerTimer
         this.IsPaused = false;
         this.IsPracticeMode = false;
         this.IsStageMode = false;
+        this.IsBonusMode = false;
         this.CurrentRunData.Reset();
     }
 

--- a/src/SurfTimer.cs
+++ b/src/SurfTimer.cs
@@ -57,7 +57,7 @@ public partial class SurfTimer : BasePlugin
     {
         // Initialise Map Object
         // To-do: It seems like players connect very quickly and sometimes `CurrentMap` is null when it shouldn't be, lowered the timer ot 1.0 seconds for now
-        if ((CurrentMap == null || CurrentMap.Name != mapName) && mapName.Contains("surf_"))
+        if ((CurrentMap == null || CurrentMap.Name.Equals(mapName) == false) && mapName.Contains("surf_"))
         {
             AddTimer(1.0f, () => CurrentMap = new Map(mapName, DB!)); // Was 3 seconds, now 1 second
         }


### PR DESCRIPTION
Changelog:

- [X] Disable hibernation in default server config file.
- [X] Fix minor display bug with compact time formatting style.
- [X] Fix `run_time` DB variable references being the wrong data type.
- [X] Fix an issue with stages being indexed inconveniently when zones are iterated over by the timer on map change.
- [ ] Implement bonuses (**W.I.P**)
  - [X] `!b` and `!bonus` commands
  - [X] Bonus zone hooks
  - [ ] Bonus time saving
  - [ ] Bonus replay saving