### PR TITLE
Fix: prevent bonus triggers from overriding main start zone

### DIFF
--- a/src/ST-Map/Map.cs
+++ b/src/ST-Map/Map.cs
@@ -149,9 +149,10 @@ public class Map : MapEntity
             if (trigger.Entity!.Name != null)
             {
                 // Map start zone
-                if (trigger.Entity!.Name.Contains("map_start") ||
+                if ((trigger.Entity!.Name.Contains("map_start") ||
                     trigger.Entity!.Name.Contains("stage1_start") ||
-                    trigger.Entity!.Name.Contains("s1_start"))
+                    trigger.Entity!.Name.Contains("s1_start")) &&
+                    !trigger.Entity!.Name.Contains("bonus")) // Prevents setting bonus as start zone (e.g. bonus1_start)
                 {
                     bool foundPlayerSpawn = false; // Track whether a player spawn is found
                     foreach (CBaseEntity teleport in teleports)


### PR DESCRIPTION
Fixed a bug where maps that contain 'bonus1_start' that would accidentally overwrite the main map's start zone. Not only breaking the reset but also bonus commands.